### PR TITLE
Fix to markdown Headings, missing spaces.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="https://www.python.org/static/img/python-logo@2x.png" alt="Python Logo" height="50px"/>
 
-#Treehouse Python Web Techdegree Resources
+# Treehouse Python Web Techdegree Resources
 
 
 This is a community based list of resources for the [Python Techdegree](https://www.teamtreehouse.com). 
@@ -19,11 +19,17 @@ Want to help and add resources? Awesome! Checkout our [CONTRIBUTING guidelines](
 
 -------
  
-###Python
+#### Python
 
 * **[Django Framework](https://www.djangoproject.com/)**
+	* **[Django Admin](https://docs.djangoproject.com/en/1.10/ref/contrib/admin/)**
     * **[Django Authentication](https://docs.djangoproject.com/en/1.10/topics/auth/)**
+    * **[Django Models](https://docs.djangoproject.com/en/1.10/topics/db/models/)**
     * **[Django REST framework](http://www.django-rest-framework.org/)**
+    * **[Django Settings](https://docs.djangoproject.com/en/1.10/topics/settings/)**
+    * **[Django Signals](https://docs.djangoproject.com/en/1.10/topics/signals/)**
+    * **[Django Templates](https://docs.djangoproject.com/en/1.10/topics/templates/)**
+    * **[Django Views](https://docs.djangoproject.com/en/1.10/topics/http/views/)**
 
 * **[Flask Framework](http://flask.pocoo.org/)**
     * **[Peewee ORM](https://peewee.readthedocs.io/en/latest/)**
@@ -33,29 +39,29 @@ Want to help and add resources? Awesome! Checkout our [CONTRIBUTING guidelines](
 * **[Python Site](https://www.python.org/)**
 
 
-###HTML
+#### HTML
 
 * **[HTML Validation](https://validator.w3.org/)**
 
-###CSS
+#### CSS
 
 * **[CSS Validation](https://jigsaw.w3.org/css-validator/)**
 
-###JavaScript
+#### JavaScript
 
 * **[JavaScript MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript)**
 * **[JS Hint](http://jshint.com/)** - A JavaScript validator
 
-###General
+#### General
 
 * 
 
-###Slack
+#### Slack
 
 * **[How to Pin items](https://get.slack.help/hc/en-us/articles/205239997-Pin-messages-or-files)**
 * **[Setting a reminder](https://get.slack.help/hc/en-us/articles/208423427-Set-a-reminder)**
 
-###Career
+#### Career
 
 * **[Django Jobs](https://www.djangojobs.net/jobs/)**
 


### PR DESCRIPTION
Heading markdown was missing spaces just after the #, so headings were not showing properly.